### PR TITLE
API Key load balancing system

### DIFF
--- a/apps/oversight/Cargo.toml
+++ b/apps/oversight/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-seyeon_trading_engine = { path = "../../crates/seyeon_trading_engine" }
+seyeon_trading_engine = "0.1.0" # Replace with the actual version of seyeon_trading_engine
 seyeon_rapidapi = { path = "../../crates/seyeon_rapidapi" }
 seyeon_cryptocompare = { path = "../../crates/seyeon_cryptocompare" }
 seyeon_redis = { path = "../../crates/seyeon_redis" }

--- a/apps/oversight/Cargo.toml
+++ b/apps/oversight/Cargo.toml
@@ -1,15 +1,15 @@
 [package]
 name = "oversight"
 version = "0.1.0"
-edition = "2024"
+edition = "2021"
 
 [dependencies]
-seyeon_trading_engine = { version = "0.1.0", path = "../../crates/seyeon_trading_engine" }
+seyeon_trading_engine = { path = "../../crates/seyeon_trading_engine" }
 seyeon_rapidapi = { path = "../../crates/seyeon_rapidapi" }
 seyeon_cryptocompare = { path = "../../crates/seyeon_cryptocompare" }
+seyeon_redis = { path = "../../crates/seyeon_redis" }
 seyeon_shared_models = { path = "../../crates/seyeon_shared_models" }
 seyeon_email = { path = "../../crates/seyeon_email" }
-seyeon_redis = { path = "../../crates/seyeon_redis" }
 polars_excel_writer = "0.12.0"
 polars = { version = "0.46.0", features = [
     "abs",
@@ -29,7 +29,7 @@ tokio = { version = "1.37.0", features = ["full"] }
 anyhow = "1.0.96"
 chrono = { version = "0.4.38", features = ["serde"] }
 dotenv = "0.15.0"
-serde = { version = "1.0", features = ["derive"] }
-serde_json = "1.0"
-thiserror = "2.0.12"
-redis = { version = "0.24.0", features = ["tokio-comp"] }
+serde = { version = "1.0.197", features = ["derive"] }
+serde_json = "1.0.115"
+thiserror = "1.0.57"
+rand = "0.8.5"


### PR DESCRIPTION
This PR adds functionality to **distribute API requests** across multiple API keys to prevent **rate limiting issues**. Now, environment variables can accept a **comma-separated list of API keys**, and the system will **randomly select one per request**, helping to:

- **Reduce the likelihood of hitting rate limits** from CryptoCompare and RapidAPI
- **Distribute load** across multiple API keys for **better reliability**
- **Support easy scaling** by simply adding more keys to environment variables
- **Maintain backward compatibility** with single key configurations

Implementation includes a **new helper function** for random key selection and **detailed logging** to show key availability. This enhancement will be particularly useful during **peak usage times** when making many concurrent API requests.